### PR TITLE
2x image rendering at 1x on iPod Touch with iOS 7.1.2

### DIFF
--- a/UIImage+AssetLaunchImage.m
+++ b/UIImage+AssetLaunchImage.m
@@ -61,7 +61,7 @@ static NSString * const kAssetImageSizeFormatString						= @"{%.0f,%.0f}";
 		[imageNameString appendFormat:kAssetImageHeightFormatString, screenHeight];
 	}
 	if (scale > 1) {
-		[imageNameString appendFormat:kAssetImageScaleFormatString, scale];
+//		[imageNameString appendFormat:kAssetImageScaleFormatString, scale];
 	}
 	if (isiPad) {
 		[imageNameString appendString:kAssetImageiPadPostfix];


### PR DESCRIPTION
While testing on a 5th gen iPod Touch with iOS 7.1.2, it seems that specifying the "@2x" identifier effectively renders the @2x launch image at 1x. (Debugging the returned image's `.scale` property prints "1.0".) Commenting this line out and allowing iOS to presence check (and use) the @2x identifier seems to fix the issue. (Verified on a retina iPad with iOS 8.0 an an iPhone 6 with iOS 8.1.1)
