### PR TITLE
update README for swift-object mix project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ This category is available via [CocoaPods](http://cocoapods.org/). Add the follo
       pod 'UIImage+AssetLaunchImage', '~> 1.0.1'
       
 Alternatively just drag&drop files to your project.
+
+
+For Swift bridge using “XXX-Bridging-Header.h”, add line bellow:
+
+      #import <UIImage_AssetLaunchImage/UIImage+AssetLaunchImage.h>


### PR DESCRIPTION
Avoid try to use #import <UIImage+AssetLaunchImage/UIImage+AssetLaunchImage.h> but always failed.
Root cause is pod will build this as framework name UIImage_AssetLaunchImage
